### PR TITLE
release 3.2.1-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install, use the following maven coordinates:
 <dependency>
   <groupId>io.github.metarank</groupId>
   <artifactId>lightgbm4j</artifactId>
-  <version>3.2.0-2</version>
+  <version>3.2.1-1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.metarank</groupId>
     <artifactId>lightgbm4j</artifactId>
-    <version>3.2.0-2</version>
+    <version>3.2.1-1</version>
 
     <name>LightGBM4j: Java LightGBM wrapper</name>
     <description>A high-level wrapper for LightGBM toolkit</description>

--- a/src/main/resources/linux/x86_64/lib_lightgbm.so
+++ b/src/main/resources/linux/x86_64/lib_lightgbm.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9250ac72d167cba7bfafe5bd0c6ff470966b77697c098e14e1b49cbbb0cc1c44
-size 5504481
+oid sha256:ce8fdff8c8f6eae83fe60170fcf6b4e86ee77f045eb49d9934c317ef7edf3c67
+size 5504501

--- a/src/main/resources/osx/x86_64/lib_lightgbm.dylib
+++ b/src/main/resources/osx/x86_64/lib_lightgbm.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05a91ff82ed9b554f9da50db34e65730900807d86d787bd4d63a302a0f7e9294
-size 3758424
+oid sha256:e3cbd5256cc583956fda470f51e20d79b3af33aca4ba15e39d5466c9620e393b
+size 3758448

--- a/src/main/resources/windows/x86_64/lib_lightgbm.dll
+++ b/src/main/resources/windows/x86_64/lib_lightgbm.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b140c0eeab4225c4216c8bddbd03d38edc3b0965ef417cf4c0aabea14b6cfdd5
+oid sha256:e7ee5cf5bc30696456e71f77ece813fede2a4f4f36fd1fb0d8cc6e82e5dba92d
 size 2167296

--- a/src/main/resources/windows/x86_64/lib_lightgbm_swig.dll
+++ b/src/main/resources/windows/x86_64/lib_lightgbm_swig.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2cb1754f3e3022962513082a6841985bfd65ddd3495640c8f8e92ede1285696a
+oid sha256:63d05cbecb4ff08352f01fe2bb3fc77bbfa4304d932f3e5f1486eb8a258ed693
 size 64512


### PR DESCRIPTION
Bump binaries to 3.2.1. There are no changes in the swig-generated java code.