### PR TITLE
Implemented memory allocation strategy for different prediction types

### DIFF
--- a/src/main/java/com/microsoft/ml/lightgbm/PredictionType.java
+++ b/src/main/java/com/microsoft/ml/lightgbm/PredictionType.java
@@ -23,6 +23,10 @@ public enum PredictionType {
         return description;
     }
 
+    public boolean equals(PredictionType that) {
+        return this.type == that.type;
+    }
+
     @Override
     public String toString() {
         return "PredictionType{" +

--- a/src/test/java/io/github/metarank/lightgbm4j/LGBMBoosterTest.java
+++ b/src/test/java/io/github/metarank/lightgbm4j/LGBMBoosterTest.java
@@ -28,16 +28,16 @@ public class LGBMBoosterTest {
 
     @Test
     public void testCreate() {
-        Assertions.assertDoesNotThrow( () -> {
-            LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        Assertions.assertDoesNotThrow(() -> {
+            LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
             LGBMBooster.create(ds, "");
         });
     }
 
     @Test
     public void testCreateFree() {
-        Assertions.assertDoesNotThrow( () -> {
-            LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        Assertions.assertDoesNotThrow(() -> {
+            LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
             LGBMBooster booster = LGBMBooster.create(ds, "");
             ds.close();
             booster.close();
@@ -46,7 +46,7 @@ public class LGBMBoosterTest {
 
     @Test
     public void testUpdateOneIter() throws LGBMException {
-        LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
         LGBMBooster booster = LGBMBooster.create(ds, "");
         boolean finished = booster.updateOneIter();
         ds.close();
@@ -56,7 +56,7 @@ public class LGBMBoosterTest {
 
     @Test
     public void testSaveModelToString() throws LGBMException {
-        LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
         LGBMBooster booster = LGBMBooster.create(ds, "");
         String model = booster.saveModelToString(0, 0, LGBMBooster.FeatureImportanceType.GAIN);
         ds.close();
@@ -66,12 +66,12 @@ public class LGBMBoosterTest {
 
     @Test
     public void testLoadSaveString() throws LGBMException {
-        LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
         LGBMBooster booster = LGBMBooster.create(ds, "");
         String model = booster.saveModelToString(0, 0, LGBMBooster.FeatureImportanceType.GAIN);
         ds.close();
         booster.close();
-        Assertions.assertDoesNotThrow( () -> {
+        Assertions.assertDoesNotThrow(() -> {
             LGBMBooster loaded = LGBMBooster.loadModelFromString(model);
             loaded.close();
         });
@@ -79,7 +79,7 @@ public class LGBMBoosterTest {
 
     @Test
     public void testGetFeatureNames() throws LGBMException {
-        LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
         LGBMBooster booster = LGBMBooster.create(ds, "");
         String[] names = booster.getFeatureNames();
         assertTrue(names.length > 0, "feature names should be present");
@@ -88,30 +88,81 @@ public class LGBMBoosterTest {
     }
 
     @Test
-    public void testPredictForMatFloat() throws LGBMException {
-        LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+    public void testPredictForMatFloatNormalPrediction() throws LGBMException {
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
         LGBMBooster booster = LGBMBooster.create(ds, "");
         boolean finished = booster.updateOneIter();
-        double[] pred = booster.predictForMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, PredictionType.C_API_PREDICT_NORMAL);
-        assertTrue(pred.length > 0, "predicted values should not be empty");
+        double[] pred;
+        for (int i = 0; i < 10; i++) {
+            // repeat multiple times to ensure it works
+            // offline tests showed that one execution can work, while in multiple iterations it fails
+            // valid for all types of predictions
+            pred = booster.predictForMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, PredictionType.C_API_PREDICT_NORMAL);
+            assertTrue(pred.length > 0, "predicted values should not be empty");
+        }
+        ds.close();
+        booster.close();
+    }
+
+    @Test
+    public void testPredictForMatFloatRawScorePrediction() throws LGBMException {
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMBooster booster = LGBMBooster.create(ds, "");
+        boolean finished = booster.updateOneIter();
+        double[] pred;
+        for (int i = 0; i < 10; i++) {
+            pred = booster.predictForMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, PredictionType.C_API_PREDICT_RAW_SCORE);
+            assertTrue(pred.length > 0, "predicted values should not be empty");
+        }
+        ds.close();
+        booster.close();
+    }
+
+    @Test
+    public void testPredictForMatFloatLeafIndexPrediction() throws LGBMException {
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMBooster booster = LGBMBooster.create(ds, "");
+        boolean finished = booster.updateOneIter();
+        double[] pred;
+        for (int i = 0; i < 10; i++) {
+            pred = booster.predictForMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, PredictionType.C_API_PREDICT_LEAF_INDEX);
+            assertTrue(pred.length > 0, "predicted values should not be empty");
+        }
+        ds.close();
+        booster.close();
+    }
+
+    @Test
+    public void testPredictForMatFloatContributionPrediction() throws LGBMException {
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMBooster booster = LGBMBooster.create(ds, "");
+        boolean finished = booster.updateOneIter();
+        double[] pred;
+        for (int i = 0; i < 10; i++) {
+            pred = booster.predictForMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, PredictionType.C_API_PREDICT_CONTRIB);
+            assertTrue(pred.length > 0, "predicted values should not be empty");
+        }
         ds.close();
         booster.close();
     }
 
     @Test
     public void testPredictForMatDouble() throws LGBMException {
-        LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
         LGBMBooster booster = LGBMBooster.create(ds, "");
         boolean finished = booster.updateOneIter();
-        double[] pred = booster.predictForMat(new double[] {1.0, 1.0, 1.0, 1.0}, 2, 2, true, PredictionType.C_API_PREDICT_NORMAL);
-        assertTrue(pred.length > 0, "predicted values should not be empty");
+        double[] pred;
+        for (int i = 0; i < 10; i++) {
+            pred = booster.predictForMat(new double[]{1.0, 1.0, 1.0, 1.0}, 2, 2, true, PredictionType.C_API_PREDICT_NORMAL);
+            assertTrue(pred.length > 0, "predicted values should not be empty");
+        }
         ds.close();
         booster.close();
     }
 
     @Test
     public void testAddValidData() throws LGBMException {
-        LGBMDataset ds = LGBMDataset.createFromMat(new float[] {1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
         LGBMBooster booster = LGBMBooster.create(ds, "");
         booster.addValidData(ds);
         ds.close();
@@ -157,21 +208,78 @@ public class LGBMBoosterTest {
     }
 
     @Test
-    public void testPredictForMatSingleRow() throws LGBMException {
+    public void testPredictForMatSingleRowNormalPrediction() throws LGBMException {
         LGBMDataset dataset = LGBMDataset.createFromFile("src/test/resources/cancer.csv", "header=true label=name:Classification", null);
         LGBMBooster booster = LGBMBooster.create(dataset, "objective=binary label=name:Classification");
         booster.updateOneIter();
         booster.updateOneIter();
         booster.updateOneIter();
-        double pred1 = booster.predictForMatSingleRow(new double[] {1,2,3,4,5,6,7,8,9}, PredictionType.C_API_PREDICT_NORMAL);
-        assertTrue(pred1 > 0);
-        double pred2 = booster.predictForMatSingleRow(new float[] {1,2,3,4,5,6,7,8,9}, PredictionType.C_API_PREDICT_NORMAL);
-        assertTrue(pred2 > 0);
+        for (int i = 0; i < 10; i++) {
+            double pred1 = booster.predictForMatSingleRow(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, PredictionType.C_API_PREDICT_NORMAL);
+            assertTrue(pred1 > 0);
+            double pred2 = booster.predictForMatSingleRow(new float[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, PredictionType.C_API_PREDICT_NORMAL);
+            assertTrue(pred2 > 0);
+        }
         dataset.close();
         booster.close();
     }
 
-    @Test void testCreateByReference() throws LGBMException {
+    @Test
+    public void testPredictForMatSingleRowRawScorePrediction() throws LGBMException {
+        LGBMDataset dataset = LGBMDataset.createFromFile("src/test/resources/cancer.csv", "header=true label=name:Classification", null);
+        LGBMBooster booster = LGBMBooster.create(dataset, "objective=binary label=name:Classification");
+        booster.updateOneIter();
+        booster.updateOneIter();
+        booster.updateOneIter();
+        for (int i = 0; i < 10; i++) {
+            // we assert that the result is finite, as it get both negative and positive values
+            double pred1 = booster.predictForMatSingleRow(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, PredictionType.C_API_PREDICT_RAW_SCORE);
+            assertTrue(Double.isFinite(pred1));
+            double pred2 = booster.predictForMatSingleRow(new float[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, PredictionType.C_API_PREDICT_RAW_SCORE);
+            assertTrue(Double.isFinite(pred2));
+        }
+        dataset.close();
+        booster.close();
+    }
+
+    @Test
+    public void testPredictForMatSingleRowLeafIndexPrediction() throws LGBMException {
+        LGBMDataset dataset = LGBMDataset.createFromFile("src/test/resources/cancer.csv", "header=true label=name:Classification", null);
+        LGBMBooster booster = LGBMBooster.create(dataset, "objective=binary label=name:Classification");
+        booster.updateOneIter();
+        booster.updateOneIter();
+        booster.updateOneIter();
+        for (int i = 0; i < 10; i++) {
+            // we assert that the result is finite, as it get both negative and positive values
+            double pred1 = booster.predictForMatSingleRow(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, PredictionType.C_API_PREDICT_LEAF_INDEX);
+            assertTrue(Double.isFinite(pred1));
+            double pred2 = booster.predictForMatSingleRow(new float[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, PredictionType.C_API_PREDICT_LEAF_INDEX);
+            assertTrue(Double.isFinite(pred2));
+        }
+        dataset.close();
+        booster.close();
+    }
+
+    @Test
+    public void testPredictForMatSingleRowContributionPrediction() throws LGBMException {
+        LGBMDataset dataset = LGBMDataset.createFromFile("src/test/resources/cancer.csv", "header=true label=name:Classification", null);
+        LGBMBooster booster = LGBMBooster.create(dataset, "objective=binary label=name:Classification");
+        booster.updateOneIter();
+        booster.updateOneIter();
+        booster.updateOneIter();
+        for (int i = 0; i < 10; i++) {
+            // we assert that the result is finite, as it get both negative and positive values
+            double pred1 = booster.predictForMatSingleRow(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, PredictionType.C_API_PREDICT_CONTRIB);
+            assertTrue(Double.isFinite(pred1));
+            double pred2 = booster.predictForMatSingleRow(new float[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, PredictionType.C_API_PREDICT_CONTRIB);
+            assertTrue(Double.isFinite(pred2));
+        }
+        dataset.close();
+        booster.close();
+    }
+
+    @Test
+    void testCreateByReference() throws LGBMException {
         LGBMDataset dataset1 = LGBMDataset.createFromFile("src/test/resources/cancer.csv", "header=true label=name:Classification", null);
         LGBMDataset dataset2 = LGBMDataset.createFromFile("src/test/resources/cancer.csv", "header=true label=name:Classification", dataset1);
         LGBMBooster booster = LGBMBooster.create(dataset1, "objective=binary label=name:Classification");
@@ -180,7 +288,7 @@ public class LGBMBoosterTest {
         booster.updateOneIter();
 
         booster.addValidData(dataset2);
-        double[] train  =booster.getEval(0);
+        double[] train = booster.getEval(0);
         double[] test = booster.getEval(1);
         assertEquals(train[0], test[0], 0.001);
     }


### PR DESCRIPTION
Tried to use the library in a real-time streaming application and got random memory leak errors. Debugged and noticed that for each prediction type we allocate the same memory for the output result, but it should be different. See the notes at the following links:

- https://lightgbm.readthedocs.io/en/latest/C-API.html#c.LGBM_BoosterPredictForMat
- https://lightgbm.readthedocs.io/en/latest/C-API.html#c.LGBM_BoosterPredictForMatSingleRow

In this pull request I have implemented a method to dynamically determine the memory needed for the output result based on the prediction type (at the bottom of the LGBMBooster.java class). I have also written tests for all possible prediction types.