### PR TITLE
add guard from double-close jvm crash

### DIFF
--- a/src/main/java/io/github/metarank/lightgbm4j/LGBMBooster.java
+++ b/src/main/java/io/github/metarank/lightgbm4j/LGBMBooster.java
@@ -17,6 +17,8 @@ public class LGBMBooster implements AutoCloseable {
 
     private static volatile boolean nativeLoaded = false;
 
+    private volatile boolean isClosed = false;
+
     static {
         try {
             LGBMBooster.loadNative();
@@ -171,9 +173,12 @@ public class LGBMBooster implements AutoCloseable {
      */
     @Override
     public void close() throws LGBMException {
-        int result = LGBM_BoosterFree(voidpp_value(handle));
-        if (result < 0) {
-            throw new LGBMException(LGBM_GetLastError());
+        if (!isClosed) {
+            isClosed = true;
+            int result = LGBM_BoosterFree(voidpp_value(handle));
+            if (result < 0) {
+                throw new LGBMException(LGBM_GetLastError());
+            }
         }
     }
 

--- a/src/main/java/io/github/metarank/lightgbm4j/LGBMDataset.java
+++ b/src/main/java/io/github/metarank/lightgbm4j/LGBMDataset.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import static com.microsoft.ml.lightgbm.lightgbmlib.*;
 
 public class LGBMDataset implements AutoCloseable {
+    private volatile boolean isClosed = false;
     public SWIGTYPE_p_void handle;
     static {
         try {
@@ -242,9 +243,12 @@ public class LGBMDataset implements AutoCloseable {
      */
     @Override
     public void close() throws LGBMException {
-        int result = LGBM_DatasetFree(handle);
-        if (result < 0) {
-            throw new LGBMException(LGBM_GetLastError());
+        if (!isClosed) {
+            int result = LGBM_DatasetFree(handle);
+            isClosed = true;
+            if (result < 0) {
+                throw new LGBMException(LGBM_GetLastError());
+            }
         }
     }
 }

--- a/src/test/java/io/github/metarank/lightgbm4j/LGBMBoosterTest.java
+++ b/src/test/java/io/github/metarank/lightgbm4j/LGBMBoosterTest.java
@@ -293,5 +293,12 @@ public class LGBMBoosterTest {
         assertEquals(train[0], test[0], 0.001);
     }
 
+    @Test void testDoubleClose() throws LGBMException {
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        LGBMBooster booster = LGBMBooster.create(ds, "");
+        booster.close();
+        booster.close();
+    }
+
 
 }

--- a/src/test/java/io/github/metarank/lightgbm4j/LGBMDatasetTest.java
+++ b/src/test/java/io/github/metarank/lightgbm4j/LGBMDatasetTest.java
@@ -64,4 +64,9 @@ public class LGBMDatasetTest {
         ds.close();
     }
 
+    @Test void testDoubleClose() throws LGBMException {
+        LGBMDataset ds = LGBMDataset.createFromMat(new float[]{1.0f, 1.0f, 1.0f, 1.0f}, 2, 2, true, "", null);
+        ds.close();
+        ds.close();
+    }
 }


### PR DESCRIPTION
Reproducer:
```
 dataset.close();
 dataset.close();
```
-- results in JVM crash